### PR TITLE
Allow initializing MathJax more than once

### DIFF
--- a/lib/process-math.js
+++ b/lib/process-math.js
@@ -1,7 +1,6 @@
 /*eslint no-unsafe-finally: "off"*/
 const pendingScripts = []
 const pendingCallbacks = []
-let needsProcess = false
 
 /**
  * Process math in a script node using MathJax
@@ -13,12 +12,9 @@ function processMath(MathJax, script, callback) {
   pendingScripts.push(script)
   pendingCallbacks.push(callback)
 
-  if (!needsProcess) {
-    needsProcess = true
-    setTimeout(() => {
-      return doProcess(MathJax)
-    }, 0)
-  }
+  setTimeout(() => {
+    return doProcess(MathJax)
+  }, 0)
 }
 
 function doProcess(MathJax) {


### PR DESCRIPTION
This is important because without it, `Nodes` may only be processed once. The consequence of this is that if `Nodes` are being dynamically generated, only the first one will be processed. Thus all `Nodes` created in the future will fail to render.

This PR should fix that.